### PR TITLE
[point-cloud.idl] Reintroduce method removeOctree

### DIFF
--- a/idl/hpp/agimus_idl/point-cloud.idl
+++ b/idl/hpp/agimus_idl/point-cloud.idl
@@ -57,6 +57,11 @@ module hpp {
 			    in double timeOut,
 			    in boolean newPointCloud)
 	raises (Error);
+      /// Remove octree
+      /// \param name of the link that holds the octree
+      /// \warning This method is not implemented.
+      void removeOctree(in string name) raises(Error);
+
       /// Set three points belonging to the object plan, in the object frame
       /// The (oriented) normal will be computed as $AB \times AC$ and
       /// all points behind the plan will be filtered out.

--- a/include/hpp/agimus/point-cloud.hh
+++ b/include/hpp/agimus/point-cloud.hh
@@ -73,6 +73,10 @@ namespace hpp {
 			 value_type resolution, const vector_t& configuration,
 			 value_type timeOut,
 			 bool newPointCloud);
+      /// Remove octree
+      /// \param name of the link that holds the octree
+      /// \warning This method is not implemented.
+      void removeOctree(const std::string& name);
       /// Set bounds on distance of points to sensor
       /// Points at a distance outside this interval are ignored.
       void setDistanceBounds(value_type min, value_type max);

--- a/src/point-cloud.cc
+++ b/src/point-cloud.cc
@@ -129,6 +129,11 @@ namespace hpp {
       return true;
     }
 
+    void PointCloud::removeOctree(const std::string&)
+    {
+      ROS_DEBUG_STREAM("Method PointCloud::removeOctree is not implemented.");
+    }
+
     void PointCloud::setDistanceBounds(value_type min, value_type max)
     {
       minDistance_ = min; maxDistance_ = max;


### PR DESCRIPTION
  This method is called by demonstration UR10 pointing but was not in the
  former version of point-cloud.idl. This commit reintroduce the method, but
  be aware that the method does nothing for now.